### PR TITLE
Feature/page class selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Modifiers `visible` and `hidden` for the `slide` CSS Handles
 
 ## [0.15.2] - 2020-10-29
 ### Fixed

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -171,10 +171,10 @@ const SliderTrack: FC<Props> = ({
               adjustedIndex,
               totalItems
             )}
-            className={`${applyModifiers(
-              handles.slide,
-              getFirstOrLastVisible(slidesPerPage, adjustedIndex)
-            )} flex relative`}
+            className={`${applyModifiers(handles.slide, [
+              getFirstOrLastVisible(slidesPerPage, adjustedIndex),
+              isItemVisible(adjustedIndex) ? 'visible' : 'hidden',
+            ])} flex relative`}
             data-index={
               adjustedIndex >= 0 && adjustedIndex < totalItems
                 ? adjustedIndex + 1

--- a/react/package.json
+++ b/react/package.json
@@ -21,6 +21,6 @@
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.5.0",
     "prettier": "^1.18.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5225,12 +5225,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.7.3:
+typescript@3.9.7, typescript@^3.7.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What problem is this solving?
Adding a class modifier to show which page is showing up and with this we can create a css transition with opacity.

#### How to test it?
Inspecting browser elements and see that we have no one class modifier that we can difference which page is selected.

[Current transition](https://notransition--iocea.myvtex.com/moda-feminina/blusas)

[Opacity Transition](https://opacitytransition--iocea.myvtex.com/moda-feminina/blusas)

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/9694719/101486037-d044fa80-393a-11eb-9349-9b266ded6be4.png)

#### How does this PR make you feel?
![](https://media.giphy.com/media/CAxbo8KC2A0y4/source.gif)
